### PR TITLE
Add root qmake project

### DIFF
--- a/.qmake.conf
+++ b/.qmake.conf
@@ -1,0 +1,1 @@
+VIPER_BUILD_DIR = $$shadowed($$PWD)

--- a/Browser/Browser.pro
+++ b/Browser/Browser.pro
@@ -8,8 +8,9 @@ QT       += core gui sql printsupport
 
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets webkitwidgets
 
-TARGET = Browser
+TARGET = viper-browser
 TEMPLATE = app
+DESTDIR = $$VIPER_BUILD_DIR
 
 CONFIG += c++14
 

--- a/Viper-Browser.pro
+++ b/Viper-Browser.pro
@@ -1,0 +1,2 @@
+TEMPLATE = subdirs
+SUBDIRS += Browser tests

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -1,0 +1,2 @@
+TEMPLATE = subdirs
+SUBDIRS += regexp-test


### PR DESCRIPTION
This patch adds root project. This allows building Viper-Browser from the
top level, so user doesn't have to run qmake for Browser subdirectory.

Also, changed executable name from Browser to viper-browser which I think
is more descriptive.